### PR TITLE
Create systemd service file with 0600

### DIFF
--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -150,7 +150,7 @@ func (s *systemd) Install() error {
 		return fmt.Errorf("Init already exists: %s", confPath)
 	}
 
-	f, err := os.OpenFile(confPath, os.O_WRONLY|os.O_CREATE, 0644)
+	f, err := os.OpenFile(confPath, os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes an issue where systemd complains that the service file has too high of permissions. Creating the file with `0600` removes this warning and ensures that only root can read/write the file.