### PR TITLE
Rename module kardianos/service to elastic/go-service

### DIFF
--- a/example/logging/main.go
+++ b/example/logging/main.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/kardianos/service"
+	"github.com/elastic/go-service"
 )
 
 var logger service.Logger

--- a/example/runner/runner.go
+++ b/example/runner/runner.go
@@ -14,7 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/kardianos/service"
+	"github.com/elastic/go-service"
 )
 
 // Config is the runner app config structure.

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -8,7 +8,7 @@ package main
 import (
 	"log"
 
-	"github.com/kardianos/service"
+	"github.com/elastic/go-service"
 )
 
 var logger service.Logger

--- a/example/stopPause/main.go
+++ b/example/stopPause/main.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/kardianos/service"
+	"github.com/elastic/go-service"
 )
 
 var logger service.Logger

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kardianos/service
+module github.com/elastic/go-service
 
 go 1.12
 

--- a/service.go
+++ b/service.go
@@ -18,7 +18,7 @@
 //	import (
 //		"log"
 //
-//		"github.com/kardianos/service"
+//		"github.com/elastic/go-service"
 //	)
 //
 //	var logger service.Logger
@@ -59,7 +59,7 @@
 //			logger.Error(err)
 //		}
 //	}
-package service // import "github.com/kardianos/service"
+package service // import "github.com/elastic/go-service"
 
 import (
 	"errors"

--- a/service_su_test.go
+++ b/service_su_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kardianos/service"
+	"github.com/elastic/go-service"
 )
 
 const runAsServiceArg = "RunThisAsService"

--- a/service_test.go
+++ b/service_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kardianos/service"
+	"github.com/elastic/go-service"
 )
 
 func TestRunInterrupt(t *testing.T) {


### PR DESCRIPTION
This PR renames the `github.com/kardianos/service` Go module to `github.com/elastic/go-service`.